### PR TITLE
Add accelerometer self-test function to LIS2DW12 driver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ rust-version = "1.85"
 # dependencies for all targets
 bilge = "0.2.0"
 embedded-hal-async = "1.0.0"
+embassy-time = { git = "https://github.com/embassy-rs/embassy" }
 
 [dev-dependencies]
 embedded-hal-mock = { version = "0.11.1", features = ["embedded-hal-async"] }


### PR DESCRIPTION
Add accelerometer self-test function to LIS2DW12 driver.

Run accelerometer self-test with positive and negative sign based on STMicro specifications and example:
https://github.com/STMicroelectronics/STMems_Standard_C_drivers/blob/master/lis2dw12_STdC/examples/lis2dw12_self_test.c